### PR TITLE
chore/renovate normalize rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2024 - 2025 Caleb Cushing
+// SPDX-FileCopyrightText: Copyright © 2024, 2025 Caleb Cushing
 //
 // SPDX-License-Identifier: CC0-1.0
 
@@ -6,6 +6,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended"],
   dependencyDashboard: true,
+  timezone: "UTC",
   automergeStrategy: "rebase",
   hostRules: [
     {
@@ -16,10 +17,22 @@
   packageRules: [
     {
       // remember to sync with update-java
-      // Run every day at 4am
-      schedule: ["* 4 * * *"],
+      // Run every day at 04:00 UTC (scheduled after update-java at 03:00)
+      schedule: ["0 4 * * *"],
       matchManagers: ["gradle", "gradle-wrapper"],
-      enabled: false,
+      // Open PRs for MAJOR updates only; minor/patch handled by update-java
+      matchUpdateTypes: ["major"],
+      automerge: false,
+    },
+    {
+      // Ensure Gradle plugin versions in settings files are considered
+      // Match all Java update types; run weekly and not concurrently with dev deps
+      // Weekly on Wednesday at 05:00 UTC (devDependencies run at 04:00)
+      schedule: ["0 5 * * 3"],
+      matchManagers: ["gradle"],
+      matchFileNames: ["**/settings.gradle", "**/settings.gradle.kts"],
+      matchUpdateTypes: ["major", "minor", "patch"],
+      automerge: true,
     },
     {
       matchManagers: ["github-actions"],
@@ -27,8 +40,9 @@
     },
     {
       // Run every Wednesday
-      schedule: ["* * * * 3"],
-      matchManagers: ["npm", "pip_requirements", "asdf"],
+      // Single run at 04:00 UTC
+      schedule: ["0 4 * * 3"],
+      matchManagers: ["npm", "pip-compile", "asdf"],
       groupName: "devDependencies",
       matchUpdateTypes: ["minor", "patch", "pin"],
       automerge: true,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,7 +17,7 @@
   ],
   packageRules: [
     {
-      // Runs during the 04:00 UTC hour daily (scheduled after update-java at 03:00)
+      // Runs during the 03:00 UTC hour daily (scheduled after update-java at 03:00)
       schedule: ["* 3 * * *"],
       // Use pip-compile with PEP 621 pyproject at repo root
       matchManagers: ["pip-compile"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,7 +29,7 @@
     {
       // remember to sync with update-java
       // Run every day at 04:00 UTC (scheduled after update-java at 03:00)
-      schedule: ["0 4 * * *"],
+      schedule: ["* 4 * * *"],
       matchManagers: ["gradle", "gradle-wrapper"],
       // Open PRs for MAJOR updates only; minor/patch handled by update-java
       matchUpdateTypes: ["major"],
@@ -39,7 +39,7 @@
       // Ensure Gradle plugin versions in settings files are considered
       // Match all Java update types; run weekly and not concurrently with dev deps
       // Weekly on Wednesday at 05:00 UTC (devDependencies run at 04:00)
-      schedule: ["0 5 * * 3"],
+      schedule: ["* 5 * * 3"],
       matchManagers: ["gradle"],
       matchFileNames: ["**/settings.gradle", "**/settings.gradle.kts"],
       matchUpdateTypes: ["major", "minor", "patch"],
@@ -52,7 +52,7 @@
     {
       // Run every Wednesday
       // Single run at 04:00 UTC
-      schedule: ["0 4 * * 3"],
+      schedule: ["* 4 * * 3"],
       matchManagers: ["npm", "pip-compile", "asdf"],
       groupName: "devDependencies",
       matchUpdateTypes: ["minor", "patch", "pin"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,7 +28,7 @@
     },
     {
       // remember to sync with update-java
-      // Run every day at 04:00 UTC (scheduled after update-java at 03:00)
+      // Runs during the 04:00 UTC hour daily (scheduled after update-java at 03:00)
       schedule: ["* 4 * * *"],
       matchManagers: ["gradle", "gradle-wrapper"],
       // Open PRs for MAJOR updates only; minor/patch handled by update-java
@@ -38,7 +38,7 @@
     {
       // Ensure Gradle plugin versions in settings files are considered
       // Match all Java update types; run weekly and not concurrently with dev deps
-      // Weekly on Wednesday at 05:00 UTC (devDependencies run at 04:00)
+      // Weekly on Wednesday during the 05:00 UTC hour (devDependencies window is 04:00)
       schedule: ["* 5 * * 3"],
       matchManagers: ["gradle"],
       matchFileNames: ["**/settings.gradle", "**/settings.gradle.kts"],
@@ -51,7 +51,7 @@
     },
     {
       // Run every Wednesday
-      // Single run at 04:00 UTC
+      // Window: 04:00 UTC hour on Wednesday (Renovate cron uses '*' for minutes)
       schedule: ["* 4 * * 3"],
       matchManagers: ["npm", "pip-compile", "asdf"],
       groupName: "devDependencies",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright © 2024, 2025 Caleb Cushing
+// SPDX-FileCopyrightText: Copyright © 2024 - 2025 Caleb Cushing
 //
 // SPDX-License-Identifier: CC0-1.0
 
@@ -17,6 +17,8 @@
   ],
   packageRules: [
     {
+      // Runs during the 04:00 UTC hour daily (scheduled after update-java at 03:00)
+      schedule: ["* 3 * * *"],
       // Use pip-compile with PEP 621 pyproject at repo root
       matchManagers: ["pip-compile"],
       managerFilePatterns: ["^pyproject\\.toml$"],
@@ -31,7 +33,7 @@
       // Runs during the 04:00 UTC hour daily (scheduled after update-java at 03:00)
       schedule: ["* 4 * * *"],
       matchManagers: ["gradle", "gradle-wrapper"],
-      // Open PRs for MAJOR updates only; minor/patch handled by update-java
+      // Open PRs for MAJOR updates only; minor/patch are handled elsewhere
       matchUpdateTypes: ["major"],
       automerge: false,
     },
@@ -53,7 +55,7 @@
       // Run every Wednesday
       // Window: 04:00 UTC hour on Wednesday (Renovate cron uses '*' for minutes)
       schedule: ["* 4 * * 3"],
-      matchManagers: ["npm", "pip-compile", "asdf"],
+      matchManagers: ["npm", "asdf"],
       groupName: "devDependencies",
       matchUpdateTypes: ["minor", "patch", "pin"],
       automerge: true,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,7 @@
   dependencyDashboard: true,
   timezone: "UTC",
   automergeStrategy: "rebase",
+  // Managers config will be applied via packageRules below
   hostRules: [
     {
       hostType: "maven",
@@ -15,6 +16,16 @@
     },
   ],
   packageRules: [
+    {
+      // Use pip-compile with PEP 621 pyproject at repo root
+      matchManagers: ["pip-compile"],
+      managerFilePatterns: ["^pyproject\\.toml$"],
+    },
+    {
+      // Disable legacy requirements manager; we use pip-compile with PEP 621
+      matchManagers: ["pip_requirements"],
+      enabled: false,
+    },
     {
       // remember to sync with update-java
       // Run every day at 04:00 UTC (scheduled after update-java at 03:00)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright © 2024 - 2025 Caleb Cushing
+SPDX-FileCopyrightText: Copyright © 2024, 2025 Caleb Cushing
 
 SPDX-License-Identifier: CC-BY-NC-4.0
 -->
@@ -43,9 +43,13 @@ yarn run -T postinstall
 ./gradlew dependencies
 ```
 
-If you need to run the postinstall step directly, the equivalent command is:
+If you need to run the postinstall step directly, you can recreate and use the Python lock file via pip-compile (PEP 621):
 
 ```sh
+# Regenerate requirements.txt from PEP 621 dependencies in pyproject.toml
+pip-compile -o requirements.txt pyproject.toml
+
+# Then install and set up commit hooks
 pip install -r requirements.txt && git config core.hooksPath .config/git/hooks
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright © 2024, 2025 Caleb Cushing
+SPDX-FileCopyrightText: Copyright © 2024 - 2025 Caleb Cushing
 
 SPDX-License-Identifier: CC-BY-NC-4.0
 -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright © 2025 Caleb Cushing
+#
+# SPDX-License-Identifier: CC0-1.0
+
+[project]
+name = "java-commons-tools"
+version = "0.0.0"
+description = "Local tooling dependencies (managed via pip-compile)."
+dependencies = ["reuse>=6"]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 name = "java-commons-tools"
 version = "0.0.0"
 description = "Local tooling dependencies (managed via pip-compile)."
-dependencies = ["reuse>=6"]
+dependencies = ["reuse>=6", "pip-tools"]
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: Copyright © 2025 Caleb Cushing
-#
-# SPDX-License-Identifier: CC0-1.0
-
-pip-tools
-reuse


### PR DESCRIPTION
- **chore(renovate): normalize schedules; auto-merge settings rule weekly**
- **chore(python): use pip-compile (PEP 621); remove requirements.in; docs: README pip-compile instructions**
