### PR TITLE
chore(build): trim unused entries from version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright © 2024, 2025 Caleb Cushing
+# SPDX-FileCopyrightText: Copyright © 2024 - 2025 Caleb Cushing
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright © 2024 - 2025 Caleb Cushing
+# SPDX-FileCopyrightText: Copyright © 2024, 2025 Caleb Cushing
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -9,29 +9,11 @@ spring = "3.+"
 convention = "0.3.+"
 
 [libraries]
-api-guardian = { module = "org.apiguardian:apiguardian-api" }
 assertj = "org.assertj:assertj-core:3+"
-autoservice = "com.google.auto.service:auto-service:1.+"
 checker-annotations = { module = "org.checkerframework:checker-qual", version.ref = "checker" }
-checker-core = { module = "org.checkerframework:checker", version.ref = "checker" }
-commons-io = "commons-io:commons-io:2.+"
-commons-lang = "org.apache.commons:commons-lang3:3.+"
-compile-testing = "com.google.testing.compile:compile-testing:0.+"
-equalsverifier = "nl.jqno.equalsverifier:equalsverifier:3.+"
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "ep" }
 errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "ep" }
 errorprone-nullaway = "com.uber.nullaway:nullaway:0.+"
-google-java-format = "com.google.googlejavaformat:google-java-format:+"
-guava = "com.google.guava:guava:+"
-immutables-bom = "org.immutables:bom:2+"
-immutables-annotations = { module = "org.immutables:value-annotations" }
-immutables-core = { module = "org.immutables:value" }
-jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }
-jackson-core = { module = "com.fasterxml.jackson.core:jackson-core" }
-jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
-jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml" }
-jackson-module-parameter-names = { module = "com.fasterxml.jackson.module:jackson-module-parameter-names" }
-java-parser = "com.github.javaparser:javaparser-core:3.+"
 jakarta-annotation = { module = "jakarta.annotation:jakarta.annotation-api" }
 jspecify = "org.jspecify:jspecify:1.+"
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api" }
@@ -40,58 +22,23 @@ junit-parameters = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
-log4j-api = { module = "org.apache.logging.log4j:log4j-api" }
-mockito = { module = "org.mockito:mockito-core" }
 plugin-convention-checkstyle = { module = "com.xenoterracide.gradle.convention:checkstyle", version.ref = "convention" }
 plugin-convention-coverage = { module = "com.xenoterracide.gradle.convention:coverage", version.ref = "convention" }
 plugin-convention-publish = { module = "com.xenoterracide.gradle.convention:publish", version.ref = "convention" }
 plugin-convention-spotbugs = { module = "com.xenoterracide.gradle.convention:spotbugs", version.ref = "convention" }
 plugin-dependency-analysis = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version = "3.+" }
 plugin-errorprone = "net.ltgt.gradle:gradle-errorprone-plugin:4.+"
-plugin-semver = "com.xenoterracide:gradle-semver:0.+"
-plugin-spotbugs = "com.github.spotbugs:com.github.spotbugs.gradle.plugin:6.+"
-semver = "org.semver4j:semver4j:5.+"
-slf4j-bom = "org.slf4j:slf4j-bom:2.+"
-slf4j-nop = { module = "org.slf4j:slf4j-nop" }
-slf4j-simple = { module = "org.slf4j:slf4j-simple" }
 spotbugs = "com.github.spotbugs:spotbugs:4.+"
 spring-bom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring" }
-spring-boot-core = { module = "org.springframework.boot:spring-boot" }
-spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure" }
-spring-boot-test-core = { module = "org.springframework.boot:spring-boot-test" }
-spring-boot-test-autoconfigure = { module = "org.springframework.boot:spring-boot-test-autoconfigure" }
-spring-boot-devtools = { module = "org.springframework.boot:spring-boot-devtools" }
-spring-beans = { module = "org.springframework:spring-beans" }
-spring-context = { module = "org.springframework:spring-context" }
-spring-core = { module = "org.springframework:spring-core" }
-spring-test = { module = "org.springframework:spring-test" }
-spring-security-core = { module = "org.springframework.security:spring-security-core" }
-spring-security-oauth2-core = { module = "org.springframework.security:spring-security-oauth2" }
-spring-data-commons = { module = "org.springframework.data:spring-data-commons" }
-spring-data-neo4j = { module = "org.springframework.data:spring-data-neo4j" }
-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
-starter-core = { module = "org.springframework.boot:spring-boot-starter" }
-starter-jackson = { module = "org.springframework.boot:spring-boot-starter-jackson" }
-starter-log4j2 = { module = "org.springframework.boot:spring-boot-starter-log4j2" }
-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
-starter-oauth2-client = { module = "org.springframework.boot:spring-boot-starter-oauth2-client" }
-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }
-starter-neo4j = { module = "org.springframework.boot:spring-boot-starter-data-neo4j" }
-testcontainers = "org.testcontainers:junit-jupiter:1.+"
 vavr = "io.vavr:vavr:0.+"
 
 [bundles]
 compile-annotations = ["errorprone-annotations", "checker-annotations", "jakarta-annotation"]
 ep = ["errorprone-core", "errorprone-nullaway"]
-jackson-config = ["jackson-core", "jackson-module-parameter-names"]
 test-impl = ["junit-api", "assertj", "junit-parameters"]
 test-runtime = ["junit-engine", "junit-launcher"]
-spring-test = ["spring-test", "spring-boot-test-core", "spring-boot-autoconfigure", "spring-boot-test-autoconfigure"]
 
 [plugins]
 module-testing = { id = "org.gradlex.java-module-testing", version = "1.+" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis" }
-gradle-plugin-publish = { id = "com.gradle.plugin-publish", version = "1.+" }
-shadow = { id = "com.gradleup.shadow", version = "8.+" }
 semver = { id = "com.xenoterracide.gradle.semver", version = "0.13.+" }


### PR DESCRIPTION
Remove aliases, bundles, and plugin ids that are not referenced anywhere in the project (root build, modules, or buildSrc). Keeps only the dependencies actually used by Gradle scripts and dependency-analysis excludes.\n\nCo-authored-by: Junie <caleb.cushing+junie@gmail.com>
