### PR TITLE
ci: simplify renovate config and update devtools

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
   dependencyDashboard: true,
   timezone: "UTC",
   platformAutomerge: true,
-  automergeStrategy: "squash",
+  automergeStrategy: "rebase",
   // Rebase whenever PR falls behind base branch to keep them mergeable
   rebaseWhen: "behind-base-branch",
   // Subtrees are excluded - updates should be pulled via git subtree pull, not Renovate
@@ -24,22 +24,7 @@
   ],
   packageRules: [
     {
-      matchManagers: ["maven"],
-      matchUpdateTypes: ["major", "minor", "patch"],
-      automerge: true,
-    },
-    {
-      // Python deps via uv: Run daily at 03:00 UTC (after update-java)
-      schedule: ["* 3 * * *"],
-      matchManagers: ["pep621"],
-      automerge: true,
-    },
-    {
-      matchManagers: ["pyenv"],
-      automerge: true,
-    },
-    {
-      matchManagers: ["github-actions"],
+      matchManagers: ["asdf", "maven", "npm", "pyenv", "pep621", "github-actions"],
       automerge: true,
     },
     {
@@ -47,16 +32,7 @@
       // Only these get digest pins; other actions get normal version tag updates
       matchManagers: ["github-actions"],
       matchDepNames: ["xenoterracide/**"],
-      automerge: true,
-      pinDigests: true,
-    },
-    {
-      // Run every Wednesday
-      // Window: 04:00 UTC hour on Wednesday (Renovate cron uses '*' for minutes)
-      schedule: ["* 4 * * 3"],
-      matchManagers: ["npm", "asdf"],
-      groupName: "devDependencies",
-      matchUpdateTypes: ["minor", "patch", "pin"],
+      extends: ["helpers:pinGitHubActionDigests"],
       automerge: true,
     },
   ],

--- a/.github/workflows/devtools-regression.yml
+++ b/.github/workflows/devtools-regression.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright © 2024-2026 Caleb Cushing
+#
+# SPDX-License-Identifier: MIT
+
+name: devtools-regression
+on: push
+permissions:
+  contents: read
+jobs:
+  node-cli:
+    uses: xenoterracide/github/.github/workflows/node-cli.yml@e157068784d9b512d1e1f0695b7c29853215f1ae # develop

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,13 +1,13 @@
 # SPDX-FileCopyrightText: Copyright © 2024-2026 Caleb Cushing
 #
-# SPDX-License-Identifier: CC0-1.0
+# SPDX-License-Identifier: MIT
 
-name: precommit
+name: pre-commit
 on: push
 permissions:
   contents: read
 jobs:
   license:
-    uses: xenoterracide/github/.github/workflows/license.yml@29a3d18797fea084c08dd6551099c1726baef8b4 # develop
+    uses: xenoterracide/github/.github/workflows/license.yml@e157068784d9b512d1e1f0695b7c29853215f1ae # develop
   prettier:
-    uses: xenoterracide/github/.github/workflows/prettier.yml@29a3d18797fea084c08dd6551099c1726baef8b4 # develop
+    uses: xenoterracide/github/.github/workflows/prettier.yml@e157068784d9b512d1e1f0695b7c29853215f1ae # develop


### PR DESCRIPTION
Consolidate Renovate package rules into a single automerge rule for all
managed ecosystems. Replace custom digest pinning with the built-in
`helpers:pinGitHubActionDigests` preset. Switch automerge strategy from
`squash` to `rebase`.

Add a new `devtools-regression` workflow to validate Node CLI tools on
push.

Update shared workflow SHAs to the latest develop branch. Downgrade
Java, Node.js, and Python patch versions to match current asdf tooling.

Standardize workflow SPDX license to MIT and fix pre-commit workflow
name spelling.