### PR TITLE
feat(renovate): add branchTopic for pinned GitHub action digests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,6 +33,7 @@
       matchManagers: ["github-actions"],
       matchDepNames: ["xenoterracide/**"],
       extends: ["helpers:pinGitHubActionDigests"],
+      branchTopic: "{{{depNameSanitized}}}-{{{newDigestShort}}}",
       automerge: true,
     },
   ],


### PR DESCRIPTION
Add `branchTopic` configuration to the Renovate rule that pins
`xenoterracide/**` GitHub Action digests. This ensures each pinned digest
update gets a unique, descriptive branch name based on the dependency name
and new digest short hash, preventing branch collisions and making it easier
to identify which action is being updated.
