### PR TITLE
feat(renovate): add branchTopic to package rules for better branch naming

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,7 @@
   packageRules: [
     {
       matchManagers: ["asdf", "maven", "npm", "pyenv", "pep621", "github-actions"],
+      branchTopic: "{{{depNameSanitized}}}-{{{newVersion}}}",
       automerge: true,
     },
     {


### PR DESCRIPTION
Add `branchTopic` template to Renovate package rules to generate more
descriptive branch names containing the dependency name and new version.

This improves traceability when multiple dependency updates are in
progress and makes it easier to identify which branch corresponds to
which update at a glance.