### PR TITLE
ci(github): replace node-cli with devtool-regression workflow

### DIFF
--- a/.github/workflows/devtools-regression.yml
+++ b/.github/workflows/devtools-regression.yml
@@ -7,5 +7,11 @@ on: push
 permissions:
   contents: read
 jobs:
-  node-cli:
-    uses: xenoterracide/github/.github/workflows/node-cli.yml@2cbe15e8b03a049a30e364c16cde78038c443eda # develop
+  regression-prettier:
+    uses: xenoterracide/github/.github/workflows/regression-devtool-prettier.yml@develop
+  regression-lint-staged:
+    uses: xenoterracide/github/.github/workflows/regression-devtool-lint-staged.yml@develop
+  regression-git-conventional-commits:
+    uses: xenoterracide/github/.github/workflows/regression-devtool-git-conventional-commits.yml@develop
+  regression-reuse:
+    uses: xenoterracide/github/.github/workflows/regression-devtool-reuse.yml@develop


### PR DESCRIPTION
- Replace the retired `node-cli.yml` reusable workflow in `.github/workflows/devtools-regression.yml` with direct calls to the per-tool `regression-devtool-*` workflows used by this repository:
  - `regression-devtool-prettier`
  - `regression-devtool-lint-staged`
  - `regression-devtool-git-conventional-commits`
  - `regression-devtool-reuse`
- Prefix each job ID with `regression-` so the check names are unique across all workflows in the repository.